### PR TITLE
Retitle from "React App" to "github-release-dashboard"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>github-release-dashboard</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "github-release-dashboard",
+  "name": "github-release-dashboard",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
The icon is still the React default, but at least the tab says the right thing now :)